### PR TITLE
fix(VaultRecord): Point to correct Context

### DIFF
--- a/keyhub/data_source_vaultrecord.go
+++ b/keyhub/data_source_vaultrecord.go
@@ -14,7 +14,7 @@ import (
 
 func dataSourceVaultRecord() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceVaultRecordsRead,
+		ReadContext: dataSourceVaultRecordRead,
 		Schema:      VaultRecordSchema(),
 	}
 }


### PR DESCRIPTION
This PR fixes the error while fetching a single keyhub records:

Code:
```
data "keyhub_vaultrecord" "firstvaultrecord" {
  groupuuid = ""
  uuid      = ""
}
output "firstvaultrecord" {
  value     = data.keyhub_vaultrecord.firstvaultrecord
  sensitive = true
}

```

Error:
```
test1 % terraform plan
╷
│ Error: Could not set value for vaultrecords
│
│   with data.keyhub_vaultrecord.firstvaultrecord,
│   on main.tf line 23, in data "keyhub_vaultrecord" "firstvaultrecord":
│   23: data "keyhub_vaultrecord" "firstvaultrecord" {
│
│ Invalid address to set: []string{"vaultrecords"}
╵
```