### PR TITLE
Feature/add group resource

### DIFF
--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -1,0 +1,63 @@
+---
+page_title: "keyhub_group Resource - terraform-provider-keyhub"
+subcategory: ""
+description: |-
+The group resource allows you to store/retrieve/update/delete information about one KeyHub group.
+  
+---
+
+# keyhub_group (Resource)
+
+The group resource allows you to store/retrieve/update/delete information about one KeyHub group.
+*Note:* KeyHub currently only supports the creation of a keyhub group for a client.
+Retreiving group details after creation requires adding the group details permission to the client in the KeyHub interface.
+Update or Delete isn't possible 
+
+## Example Usage
+
+```terraform
+resource "keyhub_group" "example" {
+  name = "Example"
+ 
+  member {
+    uuid = "00000000-0000-0000-0000-000000000000"
+    rights = "MANAGER"
+  }
+}
+```
+
+## Schema
+
+### Required
+
+- **name** (String) The Name field of the group
+- **member** (Block) At least one manager should be defined. *Note:* KeyHub currently only supports one member.
+
+### Optional
+
+- **description** (String) Group description
+
+- **extended_access** (String) Defines extended access. Possible values: `NOT_ALLOWED` (default), `ONE_WEEK`, `TWO_WEEKS` 
+- **vault_recovery** (String) Defines recovery strategy. Possible Values: `FULL` (default), `RECOVERY_KEY_ONLY`, `NONE`
+- **audit_months** (List of Strings) List of Months the group must be audited. Possible Values: `JANUARY`,`FEBRUARY`,`MARCH`,`APRIL`,`MAY`,`JUNE`,`JULY`,`AUGUST`,`SEPTEMBER`,`OCTOBER`,`NOVEMBER`,`DECEMBER` 
+
+
+- **rotating_password_required** (Bool) Required rotating password for members 
+- **record_trail** (Bool) Require a reason before activating a group
+- **private_group** (Bool) Set group to invite only
+- **hide_audit_trail** (Bool) Don't show audit trail in KeyHub Dashboard
+- **application_administration** (Bool) Group can be assign as managing group of an application
+- **auditor** (Bool) No idea.
+
+
+- **provisioning_auth_groupuuid** (String) UUID of the group to set as authorizing group for provisioning
+- **membership_auth_groupuuid** (String) UUID of the group to set as authorizing group for membership
+- **auditing_auth_groupuuid** (String) UUID of the group to set as authorizing group for audits
+
+ 
+### Read-Only
+
+- **id** (String) The value of the ID field of the group
+- **uuid** (String) The UUID of the group 
+
+

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -61,3 +61,10 @@ resource "keyhub_group" "example" {
 - **uuid** (String) The UUID of the group 
 
 
+## Import
+
+KeyHub group can be imported using the uuid, e.g.
+
+```
+$ terraform import keyhub_group.example "00000000-0000-0000-0000-000000000000"
+```

--- a/docs/resources/vaultrecord.md
+++ b/docs/resources/vaultrecord.md
@@ -6,7 +6,7 @@ description: |-
   
 ---
 
-# keyhub_vaultrecord (Reource)
+# keyhub_vaultrecord (Resource)
 
 The vaultrecord resource allows you to store/retrieve/update/delete information about one KeyHub vaultrecord.
 

--- a/example/group/main.tf
+++ b/example/group/main.tf
@@ -36,3 +36,27 @@ data "keyhub_group" "group" {
 output "group" {
  value = data.keyhub_group.group
 }
+
+#Create a group
+resource "keyhub_group" "new_group" {
+  name = "new_keyhub_group"
+
+  # UUID of keyhub user/account
+  member {
+    uuid = "00000000-0000-0000-0000-000000000000"
+    rights = "MANAGER"
+  }
+
+  audit_months = ["JANUARY"]
+
+  description = "This group is created by terraform"
+
+
+
+  # UUID of the group that should be set as authoring group
+  provisioning_auth_groupuuid = "00000000-0000-0000-0000-000000000000"
+  membership_auth_groupuuid   = "00000000-0000-0000-0000-000000000000"
+  auditing_auth_groupuuid     = "00000000-0000-0000-0000-000000000000"
+
+
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require github.com/hashicorp/terraform-plugin-sdk/v2 v2.16.0
 
 require (
 	github.com/google/uuid v1.3.0
-	github.com/topicuskeyhub/go-keyhub v1.0.0
+	github.com/topicuskeyhub/go-keyhub v1.1.0
 )
 
 require (
@@ -20,10 +20,6 @@ require (
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/vmihailenco/tagparser v0.1.2 // indirect
-	golang.org/x/crypto v0.0.0-20220513210258-46612604a0f9 // indirect
-	golang.org/x/net v0.0.0-20220513224357-95641704303c // indirect
-	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 // indirect
-	golang.org/x/sys v0.0.0-20220513210249-45d2b4557a2a // indirect
 	google.golang.org/genproto v0.0.0-20220505152158-f39f71e6c8f3 // indirect
 	google.golang.org/grpc v1.46.2 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require github.com/hashicorp/terraform-plugin-sdk/v2 v2.16.0
 
 require (
 	github.com/google/uuid v1.3.0
-	github.com/topicuskeyhub/go-keyhub v1.1.0
+	github.com/topicuskeyhub/go-keyhub v1.1.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -213,6 +213,7 @@ github.com/hashicorp/yamux v0.0.0-20211028200310-0bc27b27de87 h1:xixZ2bWeofWV68J
 github.com/hashicorp/yamux v0.0.0-20211028200310-0bc27b27de87/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
+github.com/jarcoal/httpmock v1.2.0/go.mod h1:oCoTsnAz4+UoOUIf5lJOWV2QQIW5UoeUI6aM2YnWAZk=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
@@ -242,6 +243,7 @@ github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcME
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
+github.com/maxatome/go-testdeep v1.11.0/go.mod h1:011SgQ6efzZYAen6fDn4BqQ+lUR72ysdyKe7Dyogw70=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -286,8 +288,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/topicuskeyhub/go-keyhub v1.0.0 h1:QlsiJN84h7JOO7JnqMiTeMH2Y1TIYt+t6mPl1JdmUTw=
-github.com/topicuskeyhub/go-keyhub v1.0.0/go.mod h1:Rgu0KQ70ezCojyxTkVUHL2nGUh8NEG/1l+t6YbJ9fGc=
+github.com/topicuskeyhub/go-keyhub v1.1.0 h1:mREICpIwcmcLxLbMhE9Tjj17cNNgWC6MQTMco5NmUJE=
+github.com/topicuskeyhub/go-keyhub v1.1.0/go.mod h1:l/203L0iEE1l/jQ3Kiz9kIKhdrO+fpjmaYY0+OpKfFE=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
@@ -326,6 +328,8 @@ golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220513210258-46612604a0f9 h1:NUzdAbFtCJSXU20AOXgeqaUwg8Ypg4MPYmL+d+rsB5c=
 golang.org/x/crypto v0.0.0-20220513210258-46612604a0f9/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e h1:T8NU3HyQ8ClP4SEE+KbFlg6n0NhuTsN4MyznaarGsZM=
+golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -395,6 +399,8 @@ golang.org/x/net v0.0.0-20211215060638-4ddde0e984e9/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220513224357-95641704303c h1:nF9mHSvoKBLkQNQhJZNsc66z2UzAMUbLGjC95CF3pU0=
 golang.org/x/net v0.0.0-20220513224357-95641704303c/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+golang.org/x/net v0.0.0-20220531201128-c960675eff93 h1:MYimHLfoXEpOhqd/zgoA/uoXzHB86AEky4LAx5ij9xA=
+golang.org/x/net v0.0.0-20220531201128-c960675eff93/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -403,6 +409,8 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 h1:OSnWWcOd/CtWQC2cYSBgbTSJv3ciqd8r54ySIW2y3RE=
 golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
+golang.org/x/oauth2 v0.0.0-20220524215830-622c5d57e401 h1:zwrSfklXn0gxyLRX/aR+q6cgHbV/ItVyzbPlbA+dkAw=
+golang.org/x/oauth2 v0.0.0-20220524215830-622c5d57e401/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -457,6 +465,8 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220513210249-45d2b4557a2a h1:N2T1jUrTQE9Re6TFF5PhvEHXHCguynGhKjWVsIUt5cY=
 golang.org/x/sys v0.0.0-20220513210249-45d2b4557a2a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/go.sum
+++ b/go.sum
@@ -290,6 +290,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/topicuskeyhub/go-keyhub v1.1.0 h1:mREICpIwcmcLxLbMhE9Tjj17cNNgWC6MQTMco5NmUJE=
 github.com/topicuskeyhub/go-keyhub v1.1.0/go.mod h1:l/203L0iEE1l/jQ3Kiz9kIKhdrO+fpjmaYY0+OpKfFE=
+github.com/topicuskeyhub/go-keyhub v1.1.1 h1:gLAGRnoMXCow2LAUZs5WrWLJTvHHFd5IE4TGzUb6Yl8=
+github.com/topicuskeyhub/go-keyhub v1.1.1/go.mod h1:l/203L0iEE1l/jQ3Kiz9kIKhdrO+fpjmaYY0+OpKfFE=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/keyhub/data_source_group.go
+++ b/keyhub/data_source_group.go
@@ -2,6 +2,8 @@ package keyhub
 
 import (
 	"context"
+	"fmt"
+	keyhubmodel "github.com/topicuskeyhub/go-keyhub/model"
 	"strconv"
 
 	"github.com/google/uuid"
@@ -29,6 +31,88 @@ func GroupSchema() map[string]*schema.Schema {
 			Required: true,
 		},
 		"name": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"description": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"extended_access": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"vault_recovery": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"audit_months": {
+			Type: schema.TypeList,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+			Computed: true,
+		},
+
+		"member": {
+			Type:     schema.TypeSet,
+			Computed: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"uuid": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"rights": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"name": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+				},
+			},
+		},
+
+		"rotating_password_required": {
+			Type:     schema.TypeBool,
+			Computed: true,
+		},
+		"record_trail": {
+			Type:     schema.TypeBool,
+			Computed: true,
+		},
+		"private_group": {
+			Type:     schema.TypeBool,
+			Computed: true,
+		},
+		"hide_audit_trail": {
+			Type:     schema.TypeBool,
+			Computed: true,
+		},
+		"application_administration": {
+			Type:     schema.TypeBool,
+			Computed: true,
+		},
+		"auditor": {
+			Type:     schema.TypeBool,
+			Computed: true,
+		},
+		"single_managed": {
+			Type:     schema.TypeBool,
+			Computed: true,
+		},
+
+		"provisioning_auth_groupuuid": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"membership_auth_groupuuid": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"auditing_auth_groupuuid": {
 			Type:     schema.TypeString,
 			Computed: true,
 		},
@@ -64,28 +148,104 @@ func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, m interfac
 
 	idString := strconv.FormatInt(group.Self().ID, 10)
 	if err := d.Set("id", idString); err != nil {
-		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Error,
-			Summary:  "Could not set value for id",
-			Detail:   err.Error(),
-		})
+		diags = append(diags, NewDiagnosticSetError("id", err))
 	}
 	if err := d.Set("uuid", group.UUID); err != nil {
-		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Error,
-			Summary:  "Could not set value for uuid",
-			Detail:   err.Error(),
-		})
+		diags = append(diags, NewDiagnosticSetError("uuid", err))
 	}
 	if err := d.Set("name", group.Name); err != nil {
-		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Error,
-			Summary:  "Could not set value for name",
-			Detail:   err.Error(),
-		})
+		diags = append(diags, NewDiagnosticSetError("name", err))
+	}
+	if err := d.Set("description", group.Description); err != nil {
+		diags = append(diags, NewDiagnosticSetError("description", err))
+	}
+	if err := d.Set("extended_access", group.ExtendedAccess); err != nil {
+		diags = append(diags, NewDiagnosticSetError("extended_access", err))
+	}
+	if err := d.Set("vault_recovery", group.VaultRecovery); err != nil {
+		diags = append(diags, NewDiagnosticSetError("vault_recovery", err))
+	}
+	if err := d.Set("audit_months", group.AuditConfig.Months.ToList()); err != nil {
+		diags = append(diags, NewDiagnosticSetError("audit_months", err))
+	}
+
+	// Bools
+	if err := d.Set("rotating_password_required", group.HideAuditTrail); err != nil {
+		diags = append(diags, NewDiagnosticSetError("rotating_password_required", err))
+	}
+	if err := d.Set("record_trail", group.HideAuditTrail); err != nil {
+		diags = append(diags, NewDiagnosticSetError("record_trail", err))
+	}
+	if err := d.Set("private_group", group.HideAuditTrail); err != nil {
+		diags = append(diags, NewDiagnosticSetError("private_group", err))
+	}
+	if err := d.Set("hide_audit_trail", group.HideAuditTrail); err != nil {
+		diags = append(diags, NewDiagnosticSetError("hide_audit_trail", err))
+	}
+	if err := d.Set("application_administration", group.HideAuditTrail); err != nil {
+		diags = append(diags, NewDiagnosticSetError("application_administration", err))
+	}
+	if err := d.Set("auditor", group.HideAuditTrail); err != nil {
+		diags = append(diags, NewDiagnosticSetError("auditor", err))
+	}
+	if err := d.Set("single_managed", group.HideAuditTrail); err != nil {
+		diags = append(diags, NewDiagnosticSetError("single_managed", err))
+	}
+	if group.AuthorizingGroupProvisioning != nil {
+		if err := d.Set("provisioning_auth_groupuuid", group.AuthorizingGroupProvisioning.UUID); err != nil {
+			diags = append(diags, NewDiagnosticSetError("provisioning_auth_groupuuid", err))
+		}
+	}
+	if group.AuthorizingGroupMembership != nil {
+		if err := d.Set("membership_auth_groupuuid", group.AuthorizingGroupMembership.UUID); err != nil {
+			diags = append(diags, NewDiagnosticSetError("membership_auth_groupuuid", err))
+		}
+	}
+	if group.AuthorizingGroupAuditing != nil {
+		if err := d.Set("auditing_auth_groupuuid", group.AuthorizingGroupAuditing.UUID); err != nil {
+			diags = append(diags, NewDiagnosticSetError("auditing_auth_groupuuid", err))
+		}
+	}
+
+	if group.AdditionalObjects != nil {
+
+		if err := d.Set("member", flattenMembers(group.AdditionalObjects.Admins)); err != nil {
+			diags = append(diags, NewDiagnosticSetError("member", err))
+		}
 	}
 
 	d.SetId(strconv.FormatInt(group.Self().ID, 10))
 
 	return diags
+}
+
+func flattenMembers(members *keyhubmodel.GroupAccountList) []interface{} {
+
+	if members == nil {
+		return make([]interface{}, 0)
+	}
+
+	list := make([]interface{}, len(members.Items), len(members.Items))
+
+	for i, member := range members.Items {
+
+		m := make(map[string]interface{})
+		m["uuid"] = member.UUID
+		m["rights"] = member.Rights
+		m["name"] = member.DisplayName
+
+		list[i] = m
+
+	}
+
+	return list
+
+}
+
+func NewDiagnosticSetError(key string, err error) diag.Diagnostic {
+	return diag.Diagnostic{
+		Severity: diag.Error,
+		Summary:  fmt.Sprintf("Could not set value for %s", key),
+		Detail:   err.Error(),
+	}
 }

--- a/keyhub/data_source_group.go
+++ b/keyhub/data_source_group.go
@@ -170,25 +170,25 @@ func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, m interfac
 	}
 
 	// Bools
-	if err := d.Set("rotating_password_required", group.HideAuditTrail); err != nil {
+	if err := d.Set("rotating_password_required", group.RotatingPasswordRequired); err != nil {
 		diags = append(diags, NewDiagnosticSetError("rotating_password_required", err))
 	}
 	if err := d.Set("record_trail", group.HideAuditTrail); err != nil {
 		diags = append(diags, NewDiagnosticSetError("record_trail", err))
 	}
-	if err := d.Set("private_group", group.HideAuditTrail); err != nil {
+	if err := d.Set("private_group", group.PrivateGroup); err != nil {
 		diags = append(diags, NewDiagnosticSetError("private_group", err))
 	}
 	if err := d.Set("hide_audit_trail", group.HideAuditTrail); err != nil {
 		diags = append(diags, NewDiagnosticSetError("hide_audit_trail", err))
 	}
-	if err := d.Set("application_administration", group.HideAuditTrail); err != nil {
+	if err := d.Set("application_administration", group.ApplicationAdministration); err != nil {
 		diags = append(diags, NewDiagnosticSetError("application_administration", err))
 	}
-	if err := d.Set("auditor", group.HideAuditTrail); err != nil {
+	if err := d.Set("auditor", group.Auditor); err != nil {
 		diags = append(diags, NewDiagnosticSetError("auditor", err))
 	}
-	if err := d.Set("single_managed", group.HideAuditTrail); err != nil {
+	if err := d.Set("single_managed", group.SingleManaged); err != nil {
 		diags = append(diags, NewDiagnosticSetError("single_managed", err))
 	}
 	if group.AuthorizingGroupProvisioning != nil {

--- a/keyhub/provider.go
+++ b/keyhub/provider.go
@@ -33,6 +33,7 @@ func Provider() *schema.Provider {
 		},
 		ConfigureContextFunc: providerConfigure,
 		ResourcesMap: map[string]*schema.Resource{
+			"keyhub_group":       resourceGroup(),
 			"keyhub_vaultrecord": resourceVaultRecord(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{

--- a/keyhub/resource_group.go
+++ b/keyhub/resource_group.go
@@ -1,0 +1,336 @@
+package keyhub
+
+import (
+	"context"
+	"fmt"
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	keyhubclient "github.com/topicuskeyhub/go-keyhub"
+	"strconv"
+	"strings"
+
+	keyhubmodel "github.com/topicuskeyhub/go-keyhub/model"
+)
+
+func resourceGroup() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceGroupCreate,
+		ReadContext:   dataSourceGroupRead,
+		UpdateContext: resourceGroupUpdate,
+		DeleteContext: resourceGroupDelete,
+		Schema:        GroupResourceSchema(),
+	}
+}
+
+func GroupResourceSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"uuid": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"description": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+
+		"member": {
+			Type:     schema.TypeSet,
+			Required: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"uuid": {
+						Type:             schema.TypeString,
+						Required:         true,
+						ValidateDiagFunc: validation.ToDiagFunc(validation.IsUUID),
+					},
+					"rights": {
+						Type:             schema.TypeString,
+						Optional:         true,
+						ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"manager", "normal"}, true)),
+						Default:          "manager",
+					},
+					"name": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+				},
+			},
+		},
+
+		"extended_access": {
+			Type:     schema.TypeString,
+			Optional: true,
+			ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(
+				[]string{
+					keyhubmodel.GROUP_EXT_ACCESS_NOT,
+					keyhubmodel.GROUP_EXT_ACCESS_1W,
+					keyhubmodel.GROUP_EXT_ACCESS_2W,
+				},
+				false,
+			)),
+			Default: keyhubmodel.GROUP_EXT_ACCESS_NOT,
+		},
+		"vault_recovery": {
+			Type:     schema.TypeString,
+			Optional: true,
+			ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(
+				[]string{
+					keyhubmodel.VAULT_RECOVERY_FULL,
+					keyhubmodel.VAULT_RECOVERY_KEY_ONLY,
+					keyhubmodel.VAULT_RECOVERY_NONE,
+				},
+				false,
+			)),
+			Default: keyhubmodel.VAULT_RECOVERY_FULL,
+		},
+		"audit_months": {
+			Type: schema.TypeList,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(
+					[]string{
+						keyhubmodel.MONTH_NAME_JAN,
+						keyhubmodel.MONTH_NAME_FEB,
+						keyhubmodel.MONTH_NAME_MAR,
+						keyhubmodel.MONTH_NAME_APR,
+						keyhubmodel.MONTH_NAME_MAY,
+						keyhubmodel.MONTH_NAME_JUN,
+						keyhubmodel.MONTH_NAME_JUL,
+						keyhubmodel.MONTH_NAME_AUG,
+						keyhubmodel.MONTH_NAME_SEP,
+						keyhubmodel.MONTH_NAME_OCT,
+						keyhubmodel.MONTH_NAME_NOV,
+						keyhubmodel.MONTH_NAME_DEC,
+					},
+					false,
+				)),
+			},
+			Optional: true,
+		},
+
+		"rotating_password_required": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
+		"record_trail": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
+		"private_group": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
+		"hide_audit_trail": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
+		"application_administration": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
+		"auditor": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
+		"provisioning_auth_groupuuid": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"membership_auth_groupuuid": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"auditing_auth_groupuuid": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+	}
+}
+
+func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*keyhubclient.Client)
+	_ = client
+	// Warning or errors can be collected in a slice type
+	var diags diag.Diagnostics
+
+	name := d.Get("name").(string)
+
+	newGroup := keyhubmodel.NewEmptyGroup(name)
+
+	if d.HasChange("description") {
+		newGroup.Description = d.Get("description").(string)
+	}
+
+	/* Simple bools **/
+	if d.HasChange("rotating_password_required") {
+		newGroup.RotatingPasswordRequired = d.Get("rotating_password_required").(bool)
+	}
+	if d.HasChange("record_trail") {
+		newGroup.RecordTrail = d.Get("record_trail").(bool)
+	}
+	if d.HasChange("private_group") {
+		newGroup.PrivateGroup = d.Get("private_group").(bool)
+	}
+	if d.HasChange("hide_audit_trail") {
+		newGroup.HideAuditTrail = d.Get("hide_audit_trail").(bool)
+	}
+	if d.HasChange("application_administration") {
+		newGroup.ApplicationAdministration = d.Get("application_administration").(bool)
+	}
+	if d.HasChange("auditor") {
+		newGroup.Auditor = d.Get("auditor").(bool)
+	}
+
+	/** String values validated by validation **/
+	if d.HasChange("vault_recovery") {
+		newGroup.VaultRecovery = d.Get("vault_recovery").(string)
+	}
+	if d.HasChange("extended_access") {
+		newGroup.ExtendedAccess = d.Get("extended_access").(string)
+	}
+	if d.HasChange("audit_months") {
+		months := d.Get("audit_months").([]interface{})
+		newGroup.AuditConfig = keyhubmodel.NewGroupAuditConfig()
+		for _, month := range months {
+			newGroup.AuditConfig.Months.Enable(month.(string))
+		}
+	}
+
+	/** Convert member blocks to GroupAccounts **/
+	if d.HasChange("member") {
+		members := d.Get("member").(*schema.Set)
+		for _, memiface := range members.List() {
+			member := memiface.(map[string]interface{})
+			kh_member, err := client.Accounts.GetByUUID(uuid.MustParse(member["uuid"].(string)))
+			if err != nil {
+				diags = append(diags, diag.Diagnostic{
+					Severity: diag.Error,
+					Summary:  "Member does not exist",
+					Detail:   fmt.Sprintf("Could not find an account for member with uuid: %s", member["uuid"]),
+				})
+			} else {
+				switch strings.ToUpper(member["rights"].(string)) {
+				case keyhubmodel.GROUP_RIGHT_MANAGER:
+					newGroup.AddManager(kh_member)
+				case keyhubmodel.GROUP_RIGHT_MEMBER:
+					newGroup.AddMember(kh_member)
+				default:
+					diags = append(diags, diag.Diagnostic{
+						Severity: diag.Error,
+						Summary:  "Unknown right",
+						Detail:   fmt.Sprintf("Unexpected rights given: %s", strings.ToUpper(member["rights"].(string))),
+					})
+				}
+			}
+		}
+	}
+
+	/** Load groups by Uuid **/
+	group_keys := []string{"provisioning_auth_groupuuid", "membership_auth_groupuuid", "auditing_auth_groupuuid"}
+
+	for _, group_key := range group_keys {
+		strUuid := d.Get(group_key).(string)
+		if strUuid == "" {
+			continue
+		}
+		if d.HasChange(group_key) == false {
+			continue
+		}
+		grpUuid, err := uuid.Parse(strUuid)
+		if err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Invalid uuid",
+				Detail:   fmt.Sprintf("Value `%s` is not a valid uuid for `%s`", strUuid, group_key),
+			})
+			continue
+		}
+		kh_group, err := client.Groups.GetByUUID(grpUuid)
+		if err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Group does not exist",
+				Detail:   fmt.Sprintf("Could not find a group with uuid `%s` for `%s`", strUuid, group_key),
+			})
+			continue
+		}
+		switch group_key {
+		case "provisioning_auth_groupuuid":
+			newGroup.AuthorizingGroupProvisioning = kh_group
+		case "membership_auth_groupuuid":
+			newGroup.AuthorizingGroupMembership = kh_group
+		case "auditing_auth_groupuuid":
+			newGroup.AuthorizingGroupAuditing = kh_group
+		}
+	}
+
+	createdGroup, err := client.Groups.Create(newGroup)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Could not create group",
+			Detail:   err.Error(),
+		})
+		return diags
+	}
+
+	d.Set("uuid", createdGroup.UUID)
+	d.SetId(strconv.FormatInt(createdGroup.Self().ID, 10))
+
+	/*
+		groupJson, _ := json.MarshalIndent(newGroup, "", "  ")
+
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "New group:",
+			Detail:   fmt.Sprintf("%s", groupJson),
+		})
+	*/
+
+	return diags
+
+}
+
+func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*keyhubclient.Client)
+	_ = client
+	// Warning or errors can be collected in a slice type
+	var diags diag.Diagnostics
+
+	diags = append(diags, diag.Diagnostic{
+		Severity: diag.Warning,
+		Summary:  "Cannot update a group",
+		Detail:   "Currently Keyhub doesn't allow a client to update a group after it's created, so any changes aren't stored",
+	})
+
+	dataSourceGroupRead(ctx, d, m)
+
+	return diags
+}
+
+func resourceGroupDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*keyhubclient.Client)
+	_ = client
+	// Warning or errors can be collected in a slice type
+	var diags diag.Diagnostics
+
+	diags = append(diags, diag.Diagnostic{
+		Severity: diag.Warning,
+		Summary:  "Cannot update a group",
+		Detail:   "Currently Keyhub doesn't allow a client to delete a group. We will only delete the group from the terraform state",
+	})
+
+	d.SetId("")
+
+	return diags
+}

--- a/keyhub/resource_group.go
+++ b/keyhub/resource_group.go
@@ -21,7 +21,22 @@ func resourceGroup() *schema.Resource {
 		UpdateContext: resourceGroupUpdate,
 		DeleteContext: resourceGroupDelete,
 		Schema:        GroupResourceSchema(),
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceGroupImportContext,
+		},
 	}
+}
+
+func resourceGroupImportContext(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+
+	grpUuid, err := uuid.Parse(d.Id())
+	if err != nil {
+		return nil, fmt.Errorf("`%s` is not a valid uuid", d.Id())
+	}
+
+	d.Set("uuid", grpUuid.String())
+
+	return []*schema.ResourceData{d}, nil
 }
 
 func GroupResourceSchema() map[string]*schema.Schema {

--- a/keyhub/resource_group.go
+++ b/keyhub/resource_group.go
@@ -142,6 +142,10 @@ func GroupResourceSchema() map[string]*schema.Schema {
 			Type:     schema.TypeBool,
 			Optional: true,
 		},
+		"single_managed": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
 		"provisioning_auth_groupuuid": {
 			Type:     schema.TypeString,
 			Optional: true,


### PR DESCRIPTION
*Work in progress*

This PR will enable the provider to create groups.

Update should trigger warning and do nothing
Delete should remove the resource from the terraform state, but won't delete from keyhub

Usage:
```hcl
#Create a group
resource "keyhub_group" "new_group" {
  name = "new_keyhub_group"

  # UUID of keyhub user/account
  member {
    uuid = "00000000-0000-0000-0000-000000000000"
    rights = "MANAGER"
  }

  audit_months = ["JANUARY"]

  description = "This group is created by terraform"

  # UUID of the group that should be set as authoring group
  provisioning_auth_groupuuid = "00000000-0000-0000-0000-000000000000"
  membership_auth_groupuuid   = "00000000-0000-0000-0000-000000000000"
  auditing_auth_groupuuid     = "00000000-0000-0000-0000-000000000000"

}
```
