### PR TITLE
Feature/vault record by UUID only

### DIFF
--- a/docs/data-sources/vaultrecord.md
+++ b/docs/data-sources/vaultrecord.md
@@ -23,8 +23,11 @@ data "keyhub_vaultrecord" "example" {
 
 ### Required
 
-- **groupuuid** (String) The group UUID of the vaultrecord you wish to retrieve
 - **uuid** (String) The UUID of the vaultrecord you wish to retrieve
+
+### Optional
+
+- **groupuuid** (String) The group UUID of the vaultrecord you wish to retrieve
 
 ### Read-Only
 

--- a/docs/data-sources/vaultrecord.md
+++ b/docs/data-sources/vaultrecord.md
@@ -40,3 +40,11 @@ data "keyhub_vaultrecord" "example" {
 - **comment** (String, Sensitive) The value of the Comment field of the vaultrecord. This value is sensitive as it might contain secret information.
 - **password** (String, Sensitive)  The value of the Password field of the vaultrecord. This value is sensitive as it might contain secret information.
 - **totp** (String, Sensitive)  The value of the Totp field of the vaultrecord. This value is sensitive as it might contain secret information.
+
+## Import
+
+KeyHub group can be imported using the uuid, e.g.
+
+```
+$ terraform import keyhub_vaultrecord.example "00000000-0000-0000-0000-000000000000"
+```

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require github.com/hashicorp/terraform-plugin-sdk/v2 v2.16.0
 
 require (
 	github.com/google/uuid v1.3.0
-	github.com/topicuskeyhub/go-keyhub v1.0.0
+	github.com/topicuskeyhub/go-keyhub v1.1.0
 )
 
 require (
@@ -20,10 +20,6 @@ require (
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/vmihailenco/tagparser v0.1.2 // indirect
-	golang.org/x/crypto v0.0.0-20220513210258-46612604a0f9 // indirect
-	golang.org/x/net v0.0.0-20220513224357-95641704303c // indirect
-	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 // indirect
-	golang.org/x/sys v0.0.0-20220513210249-45d2b4557a2a // indirect
 	google.golang.org/genproto v0.0.0-20220505152158-f39f71e6c8f3 // indirect
 	google.golang.org/grpc v1.46.2 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require github.com/hashicorp/terraform-plugin-sdk/v2 v2.16.0
 
 require (
 	github.com/google/uuid v1.3.0
-	github.com/topicuskeyhub/go-keyhub v1.1.0
+	github.com/topicuskeyhub/go-keyhub v1.1.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -213,6 +213,7 @@ github.com/hashicorp/yamux v0.0.0-20211028200310-0bc27b27de87 h1:xixZ2bWeofWV68J
 github.com/hashicorp/yamux v0.0.0-20211028200310-0bc27b27de87/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
+github.com/jarcoal/httpmock v1.2.0/go.mod h1:oCoTsnAz4+UoOUIf5lJOWV2QQIW5UoeUI6aM2YnWAZk=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
@@ -242,6 +243,7 @@ github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcME
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
+github.com/maxatome/go-testdeep v1.11.0/go.mod h1:011SgQ6efzZYAen6fDn4BqQ+lUR72ysdyKe7Dyogw70=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -288,6 +290,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/topicuskeyhub/go-keyhub v1.0.0 h1:QlsiJN84h7JOO7JnqMiTeMH2Y1TIYt+t6mPl1JdmUTw=
 github.com/topicuskeyhub/go-keyhub v1.0.0/go.mod h1:Rgu0KQ70ezCojyxTkVUHL2nGUh8NEG/1l+t6YbJ9fGc=
+github.com/topicuskeyhub/go-keyhub v1.1.0 h1:mREICpIwcmcLxLbMhE9Tjj17cNNgWC6MQTMco5NmUJE=
+github.com/topicuskeyhub/go-keyhub v1.1.0/go.mod h1:l/203L0iEE1l/jQ3Kiz9kIKhdrO+fpjmaYY0+OpKfFE=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
@@ -326,6 +330,8 @@ golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220513210258-46612604a0f9 h1:NUzdAbFtCJSXU20AOXgeqaUwg8Ypg4MPYmL+d+rsB5c=
 golang.org/x/crypto v0.0.0-20220513210258-46612604a0f9/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e h1:T8NU3HyQ8ClP4SEE+KbFlg6n0NhuTsN4MyznaarGsZM=
+golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -395,6 +401,8 @@ golang.org/x/net v0.0.0-20211215060638-4ddde0e984e9/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220513224357-95641704303c h1:nF9mHSvoKBLkQNQhJZNsc66z2UzAMUbLGjC95CF3pU0=
 golang.org/x/net v0.0.0-20220513224357-95641704303c/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+golang.org/x/net v0.0.0-20220531201128-c960675eff93 h1:MYimHLfoXEpOhqd/zgoA/uoXzHB86AEky4LAx5ij9xA=
+golang.org/x/net v0.0.0-20220531201128-c960675eff93/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -403,6 +411,8 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 h1:OSnWWcOd/CtWQC2cYSBgbTSJv3ciqd8r54ySIW2y3RE=
 golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
+golang.org/x/oauth2 v0.0.0-20220524215830-622c5d57e401 h1:zwrSfklXn0gxyLRX/aR+q6cgHbV/ItVyzbPlbA+dkAw=
+golang.org/x/oauth2 v0.0.0-20220524215830-622c5d57e401/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -457,6 +467,8 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220513210249-45d2b4557a2a h1:N2T1jUrTQE9Re6TFF5PhvEHXHCguynGhKjWVsIUt5cY=
 golang.org/x/sys v0.0.0-20220513210249-45d2b4557a2a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/go.sum
+++ b/go.sum
@@ -292,6 +292,8 @@ github.com/topicuskeyhub/go-keyhub v1.0.0 h1:QlsiJN84h7JOO7JnqMiTeMH2Y1TIYt+t6mP
 github.com/topicuskeyhub/go-keyhub v1.0.0/go.mod h1:Rgu0KQ70ezCojyxTkVUHL2nGUh8NEG/1l+t6YbJ9fGc=
 github.com/topicuskeyhub/go-keyhub v1.1.0 h1:mREICpIwcmcLxLbMhE9Tjj17cNNgWC6MQTMco5NmUJE=
 github.com/topicuskeyhub/go-keyhub v1.1.0/go.mod h1:l/203L0iEE1l/jQ3Kiz9kIKhdrO+fpjmaYY0+OpKfFE=
+github.com/topicuskeyhub/go-keyhub v1.1.1 h1:gLAGRnoMXCow2LAUZs5WrWLJTvHHFd5IE4TGzUb6Yl8=
+github.com/topicuskeyhub/go-keyhub v1.1.1/go.mod h1:l/203L0iEE1l/jQ3Kiz9kIKhdrO+fpjmaYY0+OpKfFE=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/keyhub/data_source_vaultrecord.go
+++ b/keyhub/data_source_vaultrecord.go
@@ -2,6 +2,7 @@ package keyhub
 
 import (
 	"context"
+	"regexp"
 	"strconv"
 
 	"github.com/google/uuid"
@@ -66,7 +67,8 @@ func VaultRecordBaseSchema() map[string]*schema.Schema {
 		},
 		"groupuuid": {
 			Type:     schema.TypeString,
-			Required: true,
+			Computed: true,
+			Optional: true,
 		},
 		"uuid": {
 			Type:     schema.TypeString,
@@ -102,30 +104,36 @@ func dataSourceVaultRecordRead(ctx context.Context, d *schema.ResourceData, m in
 	// Warning or errors can be collected in a slice type
 	var diags diag.Diagnostics
 	var vaultRecord *keyhubmodel.VaultRecord
+	var group *keyhubmodel.Group
+	var groupUUID uuid.UUID
+	var err error
 
 	groupUUIDString := d.Get("groupuuid").(string)
-	groupUUID, err := uuid.Parse(groupUUIDString)
-	if err != nil {
-		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Error,
-			Summary:  "Field 'groupuuid' is not a valid UUID",
-			Detail:   err.Error(),
-		})
-		return diags
-	}
-	group, err := client.Groups.GetByUUID(groupUUID)
-	if err != nil {
-		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Error,
-			Summary:  "Could not GET group " + groupUUIDString + " to READ vault record(s)",
-			Detail:   err.Error(),
-		})
-		return diags
+	if groupUUIDString != "" {
+		groupUUID, err = uuid.Parse(groupUUIDString)
+		if err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Field 'groupuuid' is not a valid UUID",
+				Detail:   err.Error(),
+			})
+			return diags
+		}
+		group, err = client.Groups.GetByUUID(groupUUID)
+		if err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Could not GET group " + groupUUIDString + " to READ vault record(s)",
+				Detail:   err.Error(),
+			})
+			return diags
+		}
 	}
 
 	uuidString, valueExists := d.GetOk("uuid")
 	if valueExists {
-		UUID, err := uuid.Parse(uuidString.(string))
+		var UUID uuid.UUID
+		UUID, err = uuid.Parse(uuidString.(string))
 		if err != nil {
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
@@ -135,7 +143,11 @@ func dataSourceVaultRecordRead(ctx context.Context, d *schema.ResourceData, m in
 			return diags
 		}
 
-		vaultRecord, err = client.Vaults.GetByUUID(group, UUID, &keyhubmodel.VaultRecordAdditionalQueryParams{Secret: true})
+		if group != nil {
+			vaultRecord, err = client.Vaults.GetByUUID(group, UUID, &keyhubmodel.VaultRecordAdditionalQueryParams{Secret: true})
+		} else {
+			vaultRecord, err = client.Vaults.FindByUUIDForClient(UUID, &keyhubmodel.VaultRecordAdditionalQueryParams{Secret: true})
+		}
 		if err != nil {
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
@@ -144,21 +156,24 @@ func dataSourceVaultRecordRead(ctx context.Context, d *schema.ResourceData, m in
 			})
 			return diags
 		}
-	}
+	} else {
 
-	if d.Id() != "" {
-		ID, err := strconv.ParseInt(d.Id(), 10, 64)
-		if err != nil {
-			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Error,
-				Summary:  "Could not parse ID " + d.Id(),
-				Detail:   err.Error(),
-			})
-			return diags
-		}
+		if d.Id() != "" {
+			ID, err := strconv.ParseInt(d.Id(), 10, 64)
+			if err != nil {
+				diags = append(diags, diag.Diagnostic{
+					Severity: diag.Error,
+					Summary:  "Could not parse ID " + d.Id(),
+					Detail:   err.Error(),
+				})
+				return diags
+			}
 
-		if !valueExists {
-			vaultRecord, err = client.Vaults.GetByID(group, ID, &keyhubmodel.VaultRecordAdditionalQueryParams{Secret: true})
+			if group != nil {
+				vaultRecord, err = client.Vaults.GetByID(group, ID, &keyhubmodel.VaultRecordAdditionalQueryParams{Secret: true})
+			} else {
+				vaultRecord, err = client.Vaults.FindByIDForClient(ID, &keyhubmodel.VaultRecordAdditionalQueryParams{Secret: true})
+			}
 			if err != nil {
 				diags = append(diags, diag.Diagnostic{
 					Severity: diag.Error,
@@ -167,6 +182,7 @@ func dataSourceVaultRecordRead(ctx context.Context, d *schema.ResourceData, m in
 				})
 				return diags
 			}
+			
 		}
 	}
 
@@ -178,13 +194,40 @@ func dataSourceVaultRecordRead(ctx context.Context, d *schema.ResourceData, m in
 			Detail:   err.Error(),
 		})
 	}
-	if err := d.Set("groupuuid", group.UUID); err != nil {
-		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Error,
-			Summary:  "Could not set value for groupuuid",
-			Detail:   err.Error(),
-		})
+	if group == nil {
+		// If group is nil, retrieve group from vaultrecord url, so we can set the groupuuid parameter
+		var groupId int64
+		r, _ := regexp.Compile("^((.+)/group/([0-9]+))/vault/record/([0-9]+)")
+		matches := r.FindStringSubmatch(vaultRecord.Self().Href)
+		// 0 = full url, 1 = group url, 2 = base url, 3 = group id, 4 = record id
+		groupId, err = strconv.ParseInt(matches[3], 10, 64)
+		if err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Could not parse groupId from record url",
+				Detail:   err.Error(),
+			})
+		} else {
+			group, err = client.Groups.GetById(groupId)
+			if err != nil {
+				diags = append(diags, diag.Diagnostic{
+					Severity: diag.Error,
+					Summary:  "Could not GET group " + matches[3] + " for found vault record(s)",
+					Detail:   err.Error(),
+				})
+			}
+		}
 	}
+	if group != nil {
+		if err := d.Set("groupuuid", group.UUID); err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Could not set value for groupuuid",
+				Detail:   err.Error(),
+			})
+		}
+	}
+
 	if err := d.Set("uuid", vaultRecord.UUID); err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,

--- a/keyhub/resource_vaultrecord.go
+++ b/keyhub/resource_vaultrecord.go
@@ -2,6 +2,7 @@ package keyhub
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
 	"github.com/google/uuid"
@@ -19,7 +20,22 @@ func resourceVaultRecord() *schema.Resource {
 		UpdateContext: resourceVaultRecordUpdate,
 		DeleteContext: resourceVaultRecordDelete,
 		Schema:        VaultRecordResourceSchema(),
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceVaultRecordImportContext,
+		},
 	}
+}
+
+func resourceVaultRecordImportContext(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+
+	grpUuid, err := uuid.Parse(d.Id())
+	if err != nil {
+		return nil, fmt.Errorf("`%s` is not a valid uuid", d.Id())
+	}
+
+	d.Set("uuid", grpUuid.String())
+
+	return []*schema.ResourceData{d}, nil
 }
 
 func VaultRecordResourceSchema() map[string]*schema.Schema {


### PR DESCRIPTION
This PR will enable terraform to retreive a vaultrecord by uuid only:

```hcl
data "keyhub_vaultrecord" "test" {
  uuid = "407532c4-fa95-4588-abd4-5a156a802efd"
}
```

Also this makes it possible to import a vaultrecord resource just by uuid:
```
% terraform import keyhub_vaultrecord.test2 "407532c4-fa95-4588-abd4-5a156a802efd"
keyhub_vaultrecord.test2: Importing from ID "407532c4-fa95-4588-abd4-5a156a802efd"...
keyhub_vaultrecord.test2: Import prepared!
  Prepared keyhub_vaultrecord for import
keyhub_vaultrecord.test2: Refreshing state... [id=407532c4-fa95-4588-abd4-5a156a802efd]

Import successful!
```

Draft PR until https://github.com/topicuskeyhub/go-keyhub/pull/9 is merged and the new version is added to go.mod 