### PR TITLE
feat: Enable usage of files

### DIFF
--- a/keyhub/data_source_vaultrecord.go
+++ b/keyhub/data_source_vaultrecord.go
@@ -2,6 +2,8 @@ package keyhub
 
 import (
 	"context"
+	"encoding/base64"
+	"fmt"
 	"strconv"
 
 	"github.com/google/uuid"
@@ -34,12 +36,19 @@ func VaultRecordSchema() map[string]*schema.Schema {
 			Computed:  true,
 			Required:  false,
 		},
-		// "file":{
-		// 	Type:      schema.TypeString,
-		// 	Sensitive: true,
-		// 	Computed:  true,
-		// 	Required:  false,
-		// },
+		"file": {
+			Type:      schema.TypeString,
+			Sensitive: true,
+			Computed:  true,
+			Required:  false,
+		},
+		"base64_encoded": {
+			Type:        schema.TypeBool,
+			Sensitive:   false,
+			Optional:    true,
+			Default:     false,
+			Description: "If true, the content of `file` will be base64 encoded",
+		},
 		"comment": {
 			Type:      schema.TypeString,
 			Sensitive: true,
@@ -246,13 +255,26 @@ func dataSourceVaultRecordRead(ctx context.Context, d *schema.ResourceData, m in
 			Detail:   err.Error(),
 		})
 	}
-	// if err := d.Set("file", vaultRecord.AdditionalObjects.Secret.File); err != nil {
-	// diags = append(diags, diag.Diagnostic{
-	// 	Severity: diag.Error,
-	// 	Summary:  "Could not set value for file",
-	// 	Detail:   err.Error(),
-	// })
-	// }
+
+	if vaultRecord.AdditionalObjects.Secret.File != nil {
+		var value string
+		value = fmt.Sprintf("%s", *vaultRecord.AdditionalObjects.Secret.File)
+
+		if encoded, ok := d.GetOk("base64_encoded"); ok {
+			if encoded.(bool) {
+				value = base64.StdEncoding.EncodeToString(*vaultRecord.AdditionalObjects.Secret.File)
+			}
+		}
+
+		if err := d.Set("file", value); err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Could not set value for file",
+				Detail:   err.Error(),
+			})
+		}
+	}
+
 	if err := d.Set("comment", vaultRecord.AdditionalObjects.Secret.Comment); err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,

--- a/keyhub/resource_vaultrecord.go
+++ b/keyhub/resource_vaultrecord.go
@@ -129,7 +129,10 @@ func resourceVaultRecordCreate(ctx context.Context, d *schema.ResourceData, m in
 
 	//copy schema data to model
 	//use generic copy method. also used in UPDATE.
-	vaultRecordSchemaToModel(d, vaultRecord)
+	diags = append(diags, vaultRecordSchemaToModel(d, vaultRecord)...)
+	if diags.HasError() {
+		return diags
+	}
 
 	newVaultRecord, err := client.Vaults.Create(group, vaultRecord)
 	if err != nil {
@@ -198,7 +201,10 @@ func resourceVaultRecordUpdate(ctx context.Context, d *schema.ResourceData, m in
 
 	//copy schema data to model
 	//use generic copy method. also used in CREATE.
-	vaultRecordSchemaToModel(d, vaultRecord)
+	diags = append(diags, vaultRecordSchemaToModel(d, vaultRecord)...)
+	if diags.HasError() {
+		return diags
+	}
 
 	_, err = client.Vaults.Update(group, vaultRecord)
 	if err != nil {
@@ -268,7 +274,9 @@ func resourceVaultRecordDelete(ctx context.Context, d *schema.ResourceData, m in
 	return diags
 }
 
-func vaultRecordSchemaToModel(d *schema.ResourceData, vaultRecord *keyhubmodel.VaultRecord) {
+func vaultRecordSchemaToModel(d *schema.ResourceData, vaultRecord *keyhubmodel.VaultRecord) diag.Diagnostics {
+
+	diags := diag.Diagnostics{}
 
 	if d.HasChange("name") {
 		value := d.Get("name")
@@ -311,4 +319,6 @@ func vaultRecordSchemaToModel(d *schema.ResourceData, vaultRecord *keyhubmodel.V
 		val := value.(string)
 		vaultRecord.AdditionalObjects.Secret.Comment = &val
 	}
+
+	return diags
 }


### PR DESCRIPTION
This PR will enable the terraform provider to read and write files stored with a vaultrecord.
An optional toggle enables the base64 encoding for safe use of binary files:

Usage: 

Read from keyhub:
```hcl
data "keyhub_vaultrecord" "test" {
  groupuuid = "4c25e8df-9bba-4e63-886c-b173d62fac55"
  uuid = "041c5520-e738-4d81-b29e-ec2645989b95"
  base64_encoded = true
}

resource "local_file" "png_out2" {
  filename = "${path.module}/out2_${data.keyhub_vaultrecord.test.filename}"
  content_base64 = data.keyhub_vaultrecord.test.file
}
```

Write text to keyhub:
```hcl
data "local_file" "text_in" {
  filename = "${path.module}/test.txt"
}

resource "keyhub_vaultrecord" "text_file" {
  groupuuid = "4c25e8df-9bba-4e63-886c-b173d62fac55"
  name      = "Terraform Test record 3 - Text"
  filename  = basename(data.local_file.text_in.filename)
  file      = data.local_file.text_in.content
}

resource "local_file" "text_out" {
  filename = "${path.module}/out_${keyhub_vaultrecord.text_file.filename}"
  content  = keyhub_vaultrecord.text_file.file
}
```

Write binary to keyhub:
```hcl
data "local_file" "png_in" {
  filename = "${path.module}/43137751.png"
}

resource "keyhub_vaultrecord" "png_file" {
  groupuuid      = "4c25e8df-9bba-4e63-886c-b173d62fac55"
  name           = "Terraform Test record 3"
  filename       = basename(data.local_file.png_in.filename)
  file           = data.local_file.png_in.content_base64
  base64_encoded = true
}

resource "local_file" "png_out" {
  filename       = "${path.module}/out_${keyhub_vaultrecord.png_file.filename}"
  content_base64 = keyhub_vaultrecord.png_file.file
}

```

Validation of files: `% sha256sum test.txt out_test.txt 43137751.png out_43137751.png out2_43137751.png`
```
ae3d0b2c7e117d8724476a3996d37d02c9c82317e6608d1315336898f912c14a  test.txt
ae3d0b2c7e117d8724476a3996d37d02c9c82317e6608d1315336898f912c14a  out_test.txt
b65de3b82f536aac41011bd9aa7fe3ddc9dfe34f4710dc0d482d79f0c207ea28  43137751.png
b65de3b82f536aac41011bd9aa7fe3ddc9dfe34f4710dc0d482d79f0c207ea28  out_43137751.png
b65de3b82f536aac41011bd9aa7fe3ddc9dfe34f4710dc0d482d79f0c207ea28  out2_43137751.png
```
