### PR TITLE
feat: add nested_under_groupuuid parameter

### DIFF
--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -13,6 +13,11 @@ The group resource allows you to store/retrieve/update/delete information about 
 Retreiving group details after creation requires adding the group details permission to the client in the KeyHub interface.
 Update or Delete isn't possible 
 
+## Permission Requirements
+To set any of the `auditing_auth_groupuuid`, `membership_auth_groupuuid`, `nested_under_groupuuid`, `provisioning_auth_groupuuid` parameters 
+the client used MUST have the `Groups - Configure a group for additional authorisation or nesting` permission on the referenced group.
+
+
 ## Example Usage
 
 ```terraform
@@ -43,6 +48,7 @@ resource "keyhub_group" "example" {
 - **extended_access** (String) Defines extended access. Possible values: `NOT_ALLOWED` (default), `ONE_WEEK`, `TWO_WEEKS`
 - **hide_audit_trail** (Bool) Don't show audit trail in KeyHub Dashboard
 - **membership_auth_groupuuid** (String) The UUID of the group to set as authorizing group for membership
+- **nested_under_groupuuid** (String) The UUID of the group to nest the new group under
 - **private_group** (Bool) Set group to invite only
 - **provisioning_auth_groupuuid** (String) The UUID of the group to set as authorizing group for provisioning
 - **record_trail** (Bool) Require a reason before activating a group

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require github.com/hashicorp/terraform-plugin-sdk/v2 v2.16.0
 
 require (
 	github.com/google/uuid v1.3.0
-	github.com/topicuskeyhub/go-keyhub v1.2.0
+	github.com/topicuskeyhub/go-keyhub v1.2.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -227,8 +227,12 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/topicuskeyhub/go-keyhub v1.1.0 h1:mREICpIwcmcLxLbMhE9Tjj17cNNgWC6MQTMco5NmUJE=
+github.com/topicuskeyhub/go-keyhub v1.1.0/go.mod h1:l/203L0iEE1l/jQ3Kiz9kIKhdrO+fpjmaYY0+OpKfFE=
 github.com/topicuskeyhub/go-keyhub v1.2.0 h1:8SDs0m4PuswQPNeppJRHuZWmxC6tTYGONpge8uuLKJA=
 github.com/topicuskeyhub/go-keyhub v1.2.0/go.mod h1:FVrZjmhkNnK9ePlDP8QwAhTny2k//2vQ3o8QfTxEmiI=
+github.com/topicuskeyhub/go-keyhub v1.2.1 h1:nt50wN0rpHF7sdd7d5kb01ULly1LE39s+4K/3f98uwE=
+github.com/topicuskeyhub/go-keyhub v1.2.1/go.mod h1:FVrZjmhkNnK9ePlDP8QwAhTny2k//2vQ3o8QfTxEmiI=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/keyhub/data_source_group.go
+++ b/keyhub/data_source_group.go
@@ -139,6 +139,10 @@ func GroupSchema() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Computed: true,
 		},
+		"nested_under_groupuuid": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 	}
 }
 
@@ -228,6 +232,11 @@ func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, m interfac
 	if group.AuthorizingGroupAuditing != nil {
 		if err := d.Set("auditing_auth_groupuuid", group.AuthorizingGroupAuditing.UUID); err != nil {
 			diags = append(diags, NewDiagnosticSetError("auditing_auth_groupuuid", err))
+		}
+	}
+	if group.NestedUnder != nil {
+		if err := d.Set("nested_under_groupuuid", group.NestedUnder.UUID); err != nil {
+			diags = append(diags, NewDiagnosticSetError("nested_under_groupuuid", err))
 		}
 	}
 

--- a/keyhub/resource_group.go
+++ b/keyhub/resource_group.go
@@ -64,8 +64,8 @@ func GroupResourceSchema() map[string]*schema.Schema {
 
 		"member": {
 			Type:        schema.TypeSet,
-			Required:    true,
-			Description: "At least one manager should be defined",
+			Optional:    true,
+			Description: "At least one manager or nested_under_groupuuid should be defined",
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"uuid": {
@@ -381,6 +381,18 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, m interfac
 		case "nested_under_groupuuid":
 			newGroup.NestedUnder = kh_group.AsPrimer()
 		}
+	}
+
+	if newGroup.NestedUnder == nil && newGroup.AdditionalObjects.Admins == nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Invalid configuration",
+			Detail:   "Atleast one member of nested_under_groupuuid parameter should be set",
+		})
+	}
+
+	if diags.HasError() {
+		return diags
 	}
 
 	createdGroup, err := client.Groups.Create(newGroup)

--- a/keyhub/resource_group.go
+++ b/keyhub/resource_group.go
@@ -237,6 +237,11 @@ func GroupResourceSchema() map[string]*schema.Schema {
 			Optional:    true,
 			Description: "The UUID of the group to set as authorizing group for audits",
 		},
+		"nested_under_groupuuid": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The UUID of the group to nest the new group under",
+		},
 	}
 }
 
@@ -338,7 +343,7 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, m interfac
 	}
 
 	/** Load groups by Uuid **/
-	group_keys := []string{"provisioning_auth_groupuuid", "membership_auth_groupuuid", "auditing_auth_groupuuid"}
+	group_keys := []string{"provisioning_auth_groupuuid", "membership_auth_groupuuid", "auditing_auth_groupuuid", "nested_under_groupuuid"}
 
 	for _, group_key := range group_keys {
 		strUuid := d.Get(group_key).(string)
@@ -373,6 +378,8 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, m interfac
 			newGroup.AuthorizingGroupMembership = kh_group
 		case "auditing_auth_groupuuid":
 			newGroup.AuthorizingGroupAuditing = kh_group
+		case "nested_under_groupuuid":
+			newGroup.NestedUnder = kh_group.AsPrimer()
 		}
 	}
 

--- a/keyhub/resource_group.go
+++ b/keyhub/resource_group.go
@@ -387,7 +387,7 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, m interfac
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Invalid configuration",
-			Detail:   "Atleast one member of nested_under_groupuuid parameter should be set",
+			Detail:   "At least one member or nested_under_groupuuid parameter should be set",
 		})
 	}
 


### PR DESCRIPTION
This PR fixes issue #11 and allows a new group to be nested under another group.

The client MUST have the `Groups - Configure a group for additional authorisation or nesting` permission on the existing group