### PR TITLE
Feature/25 vaultrecord enddate

### DIFF
--- a/docs/data-sources/vaultrecord.md
+++ b/docs/data-sources/vaultrecord.md
@@ -14,7 +14,6 @@ The vaultrecord data source allows you to retrieve information about one KeyHub 
 
 ```terraform
 data "keyhub_vaultrecord" "example" {
-  groupuuid = "example"
   uuid = "example"
 }
 ```
@@ -36,6 +35,11 @@ data "keyhub_vaultrecord" "example" {
 - **url** (String) The value of the URL field of the vaultrecord
 - **username** (String) The value of the Username field of the vaultrecord
 - **filename** (String)  The value of the Filename field of the vaultrecord
+
+- **enddate** (String)  The end date for the record, formatted as yyyy-mm-dd
+- **warningperiod** (String)  How far in advance Topicus KeyHub should start displaying expiry
+  warnings. Possible values: AT_EXPIRATION, TWO_WEEKS, ONE_MONTH, TWO_MONTHS, THREE_MONTHS, SIX_MONTHS, NEVER
+
 
 - **comment** (String, Sensitive) The value of the Comment field of the vaultrecord. This value is sensitive as it might contain secret information.
 - **password** (String, Sensitive)  The value of the Password field of the vaultrecord. This value is sensitive as it might contain secret information.

--- a/docs/resources/vaultrecord.md
+++ b/docs/resources/vaultrecord.md
@@ -59,11 +59,14 @@ resource "keyhub_vaultrecord" "png_file" {
 
 ### Optional
 
-- **url** (String)
-- **username** (String)
-- **filename** (String)
-- **file** (string) Content of file 
+- **url** (String) The URL to be set on the record.
+- **username** (String) The username to be set on the record.
+- **filename** (String) The filename to be set on the record
+- **file** (string) Content of the file 
 - **base64_encoded** (boolean) (Bool) If true, the value of `file` must be base64 encoded  
+- **enddate** (String)  The end date for the record, formatted as yyyy-mm-dd
+- **warningperiod** (String)  How far in advance Topicus KeyHub should start displaying expiry
+  warnings. Possible values: AT_EXPIRATION, TWO_WEEKS, ONE_MONTH, TWO_MONTHS, THREE_MONTHS, SIX_MONTHS, NEVER
 
 At least one of the following is required:
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require github.com/hashicorp/terraform-plugin-sdk/v2 v2.16.0
 
 require (
 	github.com/google/uuid v1.3.0
-	github.com/topicuskeyhub/go-keyhub v1.2.2
+	github.com/topicuskeyhub/go-keyhub v1.2.4
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -235,6 +235,8 @@ github.com/topicuskeyhub/go-keyhub v1.2.1 h1:nt50wN0rpHF7sdd7d5kb01ULly1LE39s+4K
 github.com/topicuskeyhub/go-keyhub v1.2.1/go.mod h1:FVrZjmhkNnK9ePlDP8QwAhTny2k//2vQ3o8QfTxEmiI=
 github.com/topicuskeyhub/go-keyhub v1.2.2 h1:hySQgd46ILqjDT+6VHDjZXGxaDRlO4EvZ3wyRjF31vw=
 github.com/topicuskeyhub/go-keyhub v1.2.2/go.mod h1:FVrZjmhkNnK9ePlDP8QwAhTny2k//2vQ3o8QfTxEmiI=
+github.com/topicuskeyhub/go-keyhub v1.2.4 h1:QsjrOfqjnq4QrmbynqotZpVaxX8CV6tcPrfHJdK3FJs=
+github.com/topicuskeyhub/go-keyhub v1.2.4/go.mod h1:FVrZjmhkNnK9ePlDP8QwAhTny2k//2vQ3o8QfTxEmiI=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/keyhub/data_source_vaultrecord.go
+++ b/keyhub/data_source_vaultrecord.go
@@ -53,7 +53,20 @@ func VaultRecordSchema() map[string]*schema.Schema {
 			Sensitive: true,
 			Computed:  true,
 			Required:  false,
-		}}
+		},
+		"enddate": {
+			Type:      schema.TypeString,
+			Sensitive: false,
+			Computed:  true,
+			Required:  false,
+		},
+		"warningperiod": {
+			Type:      schema.TypeString,
+			Sensitive: false,
+			Computed:  true,
+			Required:  false,
+		},
+	}
 
 	schema := map[string]*schema.Schema{}
 	for k, v := range baseSchema {
@@ -320,6 +333,22 @@ func dataSourceVaultRecordRead(ctx context.Context, d *schema.ResourceData, m in
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Could not set value for comment",
+			Detail:   err.Error(),
+		})
+	}
+
+	if err := d.Set("enddate", vaultRecord.EndDate.Format("2006-01-02")); err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Could not set value for enddate",
+			Detail:   err.Error(),
+		})
+	}
+
+	if err := d.Set("warningperiod", vaultRecord.WarningPeriod); err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Could not set value for warning period",
 			Detail:   err.Error(),
 		})
 	}


### PR DESCRIPTION
This will fix issue #25 and implement end date and warning period 

```hcl
resource "keyhub_vaultrecord" "enddatevaultrecord" {
  groupuuid = "${local.group_uuid}"
  name = "Test Record with Enddate"
  password = "Random"
  enddate = "2023-05-10"
  warningperiod = "TWO_MONTHS"
}
```