### PR TITLE
Allow creation of GroupOnSystem without provGroups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- #22 Allow creation of GroupOnSystem without provGroups
+
 ## [1.2.2] - 2022-10-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - #22 Allow creation of GroupOnSystem without provGroups
 
+### Changed
+- go-keyhub upgraded to 1.3.0
+- Resource grouponsystem schema has changed  
+
 ## [1.2.4] - 2023-04-11
 
 ### Fixed

--- a/docs/resources/grouponsystem.md
+++ b/docs/resources/grouponsystem.md
@@ -24,8 +24,7 @@ resource "keyhub_grouponsystem" "example" {
 
   provgroup {
     group = "00000000-0000-0000-0000-000000000000"
-    securitylevel = "HIGH"
-    static = false
+    activation_required = true
   }
 
 }
@@ -54,8 +53,7 @@ resource "keyhub_grouponsystem" "example" {
 
 The *provgroup* block supports the following:
 - **group** (String, Required) The UUID of the group that will become a provisioning group for the grouponsystem
-- **securitylevel** (String) The security level. Possible values: `HIGH` (default), `MEDIUM`, `LOW`
-- **static** (Bool) If set to true the group on system will be static provisioned
+- **activation_required** (Bool) Set to false to have the group on system statically provisioned
 
 
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require github.com/hashicorp/terraform-plugin-sdk/v2 v2.16.0
 
 require (
 	github.com/google/uuid v1.3.0
-	github.com/topicuskeyhub/go-keyhub v1.2.5
+	github.com/topicuskeyhub/go-keyhub v1.3.0
 )
 
 require (

--- a/keyhub/resource_grouponsystem.go
+++ b/keyhub/resource_grouponsystem.go
@@ -103,11 +103,19 @@ func GroupOnSystemResourceSchema() map[string]*schema.Schema {
 			Optional:    true,
 			Description: "Display name of the group on provisioned system. (Only on systems that support a display name)",
 		},
+		"no_provgroup": {
+			Type:          schema.TypeBool,
+			Optional:      true,
+			ConflictsWith: []string{"provgroup"},
+			Description:   "Disable setting the owner group as the provisioning group",
+		},
+
 		"provgroup": {
-			Type:        schema.TypeSet,
-			Optional:    true,
-			Computed:    true,
-			Description: "Define the provisioning group for the grouponsystem, can be set multiple times. If omitted the owner group will be the provisioning group",
+			Type:          schema.TypeSet,
+			Optional:      true,
+			Computed:      true,
+			ConflictsWith: []string{"no_provgroup"},
+			Description:   "Define the provisioning group for the grouponsystem, can be set multiple times. If omitted the owner group will be the provisioning group",
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"group": {
@@ -366,6 +374,12 @@ func resourceGroupOnSystemCreate(ctx context.Context, d *schema.ResourceData, m 
 
 	if value, ok := d.GetOk("display_name"); ok {
 		gos.DisplayName = value.(string)
+	}
+
+	if value, ok := d.GetOk("no_provgroup"); ok {
+		if value.(bool) {
+			gos.NoProvGroups()
+		}
 	}
 
 	if _, ok := d.GetOk("provgroup"); ok {


### PR DESCRIPTION
Add no_provgroup parameter to grouponsystem resource

This will fix issue #22.

Requirements before merge: 
 - https://github.com/topicuskeyhub/go-keyhub/pull/25 needs to be merged and released
 - Versionbump `github.com/topicuskeyhub/go-keyhub` to latest version in go.mod
 
 # Usage:
 
 ```hcl
 resource "keyhub_grouponsystem" "umbrella" {

  type = "POSIX_GROUP"
  owner = "00000-0000"
  system = "00000-0000"
  name_in_system = "umbrella"
  no_provgroup = true
}
 ```