### PR TITLE
Add tflog debug to every call that could return an apiError object

### DIFF
--- a/keyhub/data_source_account.go
+++ b/keyhub/data_source_account.go
@@ -2,6 +2,7 @@ package keyhub
 
 import (
 	"context"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"strconv"
 
 	"github.com/google/uuid"
@@ -57,6 +58,7 @@ func dataSourceAccountRead(ctx context.Context, d *schema.ResourceData, m interf
 
 	account, err := client.Accounts.GetByUUID(UUID)
 	if err != nil {
+		tflog.Debug(ctx, err.Error(), apiErrorToLogFields(err))
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Could not GET account " + uuidString,

--- a/keyhub/data_source_accounts.go
+++ b/keyhub/data_source_accounts.go
@@ -2,6 +2,7 @@ package keyhub
 
 import (
 	"context"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"strconv"
 	"time"
 
@@ -35,6 +36,7 @@ func dataSourceAccountsRead(ctx context.Context, d *schema.ResourceData, m inter
 
 	accounts, err := client.Accounts.List()
 	if err != nil {
+		tflog.Debug(ctx, err.Error(), apiErrorToLogFields(err))
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Could not GET accounts",

--- a/keyhub/data_source_group.go
+++ b/keyhub/data_source_group.go
@@ -3,6 +3,7 @@ package keyhub
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	keyhubmodel "github.com/topicuskeyhub/go-keyhub/model"
 	"strconv"
 
@@ -165,6 +166,7 @@ func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, m interfac
 
 	group, err := client.Groups.GetByUUID(UUID)
 	if err != nil {
+		tflog.Debug(ctx, err.Error(), apiErrorToLogFields(err))
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Could not GET group " + uuidString,

--- a/keyhub/data_source_groups.go
+++ b/keyhub/data_source_groups.go
@@ -2,6 +2,7 @@ package keyhub
 
 import (
 	"context"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"strconv"
 	"time"
 
@@ -35,6 +36,7 @@ func dataSourceGroupsRead(ctx context.Context, d *schema.ResourceData, m interfa
 
 	groups, err := client.Groups.List()
 	if err != nil {
+		tflog.Debug(ctx, err.Error(), apiErrorToLogFields(err))
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Could not GET groups",

--- a/keyhub/data_source_provisionedsystem.go
+++ b/keyhub/data_source_provisionedsystem.go
@@ -3,6 +3,7 @@ package keyhub
 import (
 	"context"
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	keyhubclient "github.com/topicuskeyhub/go-keyhub"
@@ -83,6 +84,7 @@ func dataSourceProvisionedSystemRead(ctx context.Context, d *schema.ResourceData
 
 	system, err := client.Systems.GetByUUID(UUID)
 	if err != nil {
+		tflog.Debug(ctx, err.Error(), apiErrorToLogFields(err))
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Could not GET system " + uuidString,

--- a/keyhub/data_source_vaultrecord.go
+++ b/keyhub/data_source_vaultrecord.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"regexp"
@@ -141,6 +142,7 @@ func dataSourceVaultRecordRead(ctx context.Context, d *schema.ResourceData, m in
 		}
 		group, err = client.Groups.GetByUUID(groupUUID)
 		if err != nil {
+			tflog.Debug(ctx, err.Error(), apiErrorToLogFields(err))
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Could not GET group " + groupUUIDString + " to READ vault record(s)",
@@ -169,6 +171,7 @@ func dataSourceVaultRecordRead(ctx context.Context, d *schema.ResourceData, m in
 			vaultRecord, err = client.Vaults.FindByUUIDForClient(UUID, &keyhubmodel.VaultRecordAdditionalQueryParams{Secret: true})
 		}
 		if err != nil {
+			tflog.Debug(ctx, err.Error(), apiErrorToLogFields(err))
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Could not GET vault record " + uuidString.(string),
@@ -195,6 +198,7 @@ func dataSourceVaultRecordRead(ctx context.Context, d *schema.ResourceData, m in
 				vaultRecord, err = client.Vaults.FindByIDForClient(ID, &keyhubmodel.VaultRecordAdditionalQueryParams{Secret: true})
 			}
 			if err != nil {
+				tflog.Debug(ctx, err.Error(), apiErrorToLogFields(err))
 				diags = append(diags, diag.Diagnostic{
 					Severity: diag.Error,
 					Summary:  "Could not GET vault record " + d.Id(),

--- a/keyhub/data_source_vaultrecords.go
+++ b/keyhub/data_source_vaultrecords.go
@@ -2,6 +2,7 @@ package keyhub
 
 import (
 	"context"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"strconv"
 	"time"
 
@@ -50,6 +51,7 @@ func dataSourceVaultRecordsRead(ctx context.Context, d *schema.ResourceData, m i
 	}
 	group, err := client.Groups.GetByUUID(groupUUID)
 	if err != nil {
+		tflog.Debug(ctx, err.Error(), apiErrorToLogFields(err))
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Could not GET group " + groupUUIDString + " for vault records",
@@ -60,6 +62,7 @@ func dataSourceVaultRecordsRead(ctx context.Context, d *schema.ResourceData, m i
 
 	vaultrecords, err := client.Vaults.GetRecords(group)
 	if err != nil {
+		tflog.Debug(ctx, err.Error(), apiErrorToLogFields(err))
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Could not GET vaultrecords of group " + groupUUIDString,

--- a/keyhub/provider.go
+++ b/keyhub/provider.go
@@ -2,7 +2,11 @@ package keyhub
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	keyhubmodel "github.com/topicuskeyhub/go-keyhub/model"
 	"net/http"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -91,4 +95,22 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	}
 
 	return client, diags
+}
+
+func apiErrorToLogFields(err error) map[string]interface{} {
+
+	fields := map[string]interface{}{}
+
+	var apiError keyhubmodel.KeyhubApiError
+	if errors.As(err, &apiError) {
+		fields["code"] = fmt.Sprintf("%d", apiError.Report.Code)
+		fields["reason"] = apiError.Report.Reason
+		fields["exception"] = apiError.Report.Exception
+		fields["message"] = apiError.Report.Message
+		fields["applicationError"] = apiError.Report.ApplicationError
+		fields["stacktrace"] = strings.Join(apiError.Report.StackTrace, "\n")
+	}
+
+	return fields
+
 }

--- a/keyhub/resource_clientapplication.go
+++ b/keyhub/resource_clientapplication.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -269,6 +270,7 @@ func resourceClientApplicationRead(ctx context.Context, d *schema.ResourceData, 
 
 		clientApp, err = client.ClientApplications.GetByUUID(clientUuid)
 		if err != nil {
+			tflog.Debug(ctx, err.Error(), apiErrorToLogFields(err))
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Could not GET ClientApplication " + d.Get("id").(string),
@@ -416,6 +418,7 @@ func resourceClientApplicationCreate(ctx context.Context, d *schema.ResourceData
 
 	owner, err = client.Groups.GetByUUID(uuidOwner)
 	if err != nil {
+		tflog.Debug(ctx, err.Error(), apiErrorToLogFields(err))
 		return append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Owner does not exist",
@@ -450,6 +453,7 @@ func resourceClientApplicationCreate(ctx context.Context, d *schema.ResourceData
 
 		technicalAdministrator, err = client.Groups.GetByUUID(uuidTechnicalAdministrator)
 		if err != nil {
+			tflog.Debug(ctx, err.Error(), apiErrorToLogFields(err))
 			return append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "TechnicalAdministrator group does not exist",
@@ -549,6 +553,7 @@ func resourceClientApplicationCreate(ctx context.Context, d *schema.ResourceData
 
 	newApp, err := client.ClientApplications.Create(clientApp)
 	if err != nil {
+		tflog.Debug(ctx, err.Error(), apiErrorToLogFields(err))
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Could not create ClientApplication",

--- a/keyhub/resource_group.go
+++ b/keyhub/resource_group.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -364,6 +365,7 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, m interfac
 		}
 		kh_group, err := client.Groups.GetByUUID(grpUuid)
 		if err != nil {
+			tflog.Debug(ctx, err.Error(), apiErrorToLogFields(err))
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Group does not exist",
@@ -397,6 +399,7 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, m interfac
 
 	createdGroup, err := client.Groups.Create(newGroup)
 	if err != nil {
+		tflog.Debug(ctx, err.Error(), apiErrorToLogFields(err))
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Could not create group",

--- a/keyhub/resource_grouponsystem.go
+++ b/keyhub/resource_grouponsystem.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -301,6 +302,7 @@ func resourceGroupOnSystemCreate(ctx context.Context, d *schema.ResourceData, m 
 
 		owner, err = client.Groups.GetByUUID(uuidOwner)
 		if err != nil {
+			tflog.Debug(ctx, err.Error(), apiErrorToLogFields(err))
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Owner does not exist",
@@ -331,6 +333,7 @@ func resourceGroupOnSystemCreate(ctx context.Context, d *schema.ResourceData, m 
 
 		system, err = client.Systems.GetByUUID(uuidSystem)
 		if err != nil {
+			tflog.Debug(ctx, err.Error(), apiErrorToLogFields(err))
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "System does not exist",
@@ -411,6 +414,7 @@ func resourceGroupOnSystemCreate(ctx context.Context, d *schema.ResourceData, m 
 
 	newGos, err := client.Systems.CreateGroupOnSystem(gos)
 	if err != nil {
+		tflog.Debug(ctx, err.Error(), apiErrorToLogFields(err))
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Could not create GroupOnSystem",

--- a/keyhub/resource_vaultrecord.go
+++ b/keyhub/resource_vaultrecord.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"strconv"
 	"time"
@@ -176,6 +177,7 @@ func resourceVaultRecordCreate(ctx context.Context, d *schema.ResourceData, m in
 	}
 	group, err := client.Groups.GetByUUID(groupUUID)
 	if err != nil {
+		tflog.Debug(ctx, err.Error(), apiErrorToLogFields(err))
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Could not GET group " + groupUUIDString + " for new vault record " + name,
@@ -187,6 +189,7 @@ func resourceVaultRecordCreate(ctx context.Context, d *schema.ResourceData, m in
 	//query vaultrecords by name to prevent duplicates
 	existingVaultRecord, err := client.Vaults.List(group, &keyhubmodel.VaultRecordQueryParams{Name: name}, &keyhubmodel.VaultRecordAdditionalQueryParams{Secret: true})
 	if err != nil {
+		tflog.Debug(ctx, err.Error(), apiErrorToLogFields(err))
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Could not CREATE vaultRecord in group " + groupUUIDString,
@@ -215,6 +218,7 @@ func resourceVaultRecordCreate(ctx context.Context, d *schema.ResourceData, m in
 
 	newVaultRecord, err := client.Vaults.Create(group, vaultRecord)
 	if err != nil {
+		tflog.Debug(ctx, err.Error(), apiErrorToLogFields(err))
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Could not CREATE vaultRecord in group " + groupUUIDString,
@@ -260,6 +264,7 @@ func resourceVaultRecordUpdate(ctx context.Context, d *schema.ResourceData, m in
 
 	group, err := client.Groups.GetByUUID(groupUUID)
 	if err != nil {
+		tflog.Debug(ctx, err.Error(), apiErrorToLogFields(err))
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Could not GET group " + groupUUIDString + " for vault record " + d.Id(),
@@ -270,6 +275,7 @@ func resourceVaultRecordUpdate(ctx context.Context, d *schema.ResourceData, m in
 
 	vaultRecord, err := client.Vaults.GetByID(group, ID, &keyhubmodel.VaultRecordAdditionalQueryParams{Secret: true})
 	if err != nil {
+		tflog.Debug(ctx, err.Error(), apiErrorToLogFields(err))
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Could not GET vault record " + d.Id(),
@@ -287,6 +293,7 @@ func resourceVaultRecordUpdate(ctx context.Context, d *schema.ResourceData, m in
 
 	_, err = client.Vaults.Update(group, vaultRecord)
 	if err != nil {
+		tflog.Debug(ctx, err.Error(), apiErrorToLogFields(err))
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Could not UPDATE vault record " + vaultRecord.UUID,
@@ -309,6 +316,7 @@ func resourceVaultRecordDelete(ctx context.Context, d *schema.ResourceData, m in
 	groupUUIDString := d.Get("groupuuid").(string)
 	groupUUID, err := uuid.Parse(groupUUIDString)
 	if err != nil {
+		tflog.Debug(ctx, err.Error(), apiErrorToLogFields(err))
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Field 'groupuuid' is not a valid UUID",
@@ -328,6 +336,7 @@ func resourceVaultRecordDelete(ctx context.Context, d *schema.ResourceData, m in
 
 	group, err := client.Groups.GetByUUID(groupUUID)
 	if err != nil {
+		tflog.Debug(ctx, err.Error(), apiErrorToLogFields(err))
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Could not GET group " + groupUUIDString + " for vault record " + d.Id(),
@@ -338,6 +347,7 @@ func resourceVaultRecordDelete(ctx context.Context, d *schema.ResourceData, m in
 
 	err = client.Vaults.DeleteByID(group, ID)
 	if err != nil {
+		tflog.Debug(ctx, err.Error(), apiErrorToLogFields(err))
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Could not DELETE vaultrecord " + d.Id(),


### PR DESCRIPTION
This will fix issue #19 and will throw a debug log for every call that could return an KeyhubApiError error object.


# Example output:

`TF_LOG_PROVIDER=TRACE terraform apply` 
```
2023-02-24T14:43:42.203+0100 [DEBUG] provider.terraform-provider-keyhub: Could not create GroupOnSystem. Error: HTTP 500 Internal Server Error: code=500 tf_req_id=ca04033e-743d-4906-f955-0e2e25709f58 @module=provider applicationError=NAME_ALREADY_IN_USE stacktrace="nl.topicus.cobra.restcontract.exception.RestWebApplicationException: HTTP 500 Internal Server Error
	at nl.topicus.keyhub.rest.provisioning.ProvisioningException.constructRestException(ProvisioningException.java:160)
	at nl.topicus.keyhub.rest.GroupOnSystemResourceService.create(GroupOnSystemResourceService.java:135)
	......
	at org.xnio.XnioWorker$WorkerThreadFactory$1$1.run(XnioWorker.java:1282)
	at java.lang.Thread.run(null:-1)
" tf_provider_addr=provider exception=nl.topicus.cobra.restcontract.exception.RestWebApplicationException message="HTTP 500 Internal Server Error" reason="Internal Server Error" tf_resource_type=keyhub_grouponsystem tf_rpc=ApplyResourceChange @caller=/path/to/resource_grouponsystem.go:417 timestamp=2023-02-24T14:43:42.202+0100
```

Containing the fields:
- code
- reason
- exception
- message
- applicationError
- stacktrace

